### PR TITLE
Normalize query string from NFD to NFC

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import json
+import unicodedata
 from datetime import datetime
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'libs'))
@@ -26,7 +27,7 @@ def make_data(data):
     }
 
 
-query = sys.argv[1]
+query = unicodedata.normalize('NFC', sys.argv[1].decode('utf-8'))
 token = os.environ['token']
 url = 'https://api.dropboxapi.com/2/paper/docs/search'
 limit = 100


### PR DESCRIPTION
Thank you for your great product!

I noticed this workflow cannot filter articles correctly when the query includes sonant marks.

According to my research, Alfred seems to treat input strings as NFD UTF-8.
We need to normalize input strings for filtering documents correctly.

This pull request has one way of difference for normalize string.
If you are good, please merge this p-r and release a new version.